### PR TITLE
Fix homepage routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is in case I stopped caring about my guide, anyone else can continue it
 
 Then:
 
-pip install mkdocs-material
+pip install -r requirements.txt
 
 to create new: mkdocs new .
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+<!-- Redirects to jp-lazy-guide/index.md -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Lazy Guide
-site_url: https://lazyguidejp.github.io/jp-lazy-guide/
+site_url: https://lazyguidejp.github.io/
 site_description: 'Preconfigured tools for Japanese learning'
 site_author: LazyGuideJP
 nav:
@@ -120,6 +120,9 @@ markdown_extensions:
 
 plugins:
   - git-revision-date-localized
+  - redirects:
+      redirect_maps:
+        'index.md': 'jp-lazy-guide/index.md'
   - search:
       lang:
         - en

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs==1.6.1
+mkdocs-git-revision-date-localized-plugin==1.4.7
+mkdocs-redirects==1.2.2


### PR DESCRIPTION
Hello, and firstly thank you for this site! It's a great resource to have and I used most of it for my immersion setup.

I noticed that when navigating to the site from Google, it takes me to a broken page, and I think this is because the `jp-lazy-guide` suffix is repeated in `mkdocs.yml`. As well as this, it seems without having an `index.md` in the `docs` folder, all that is shown is a broken page.

<img width="1069" height="1043" alt="Image" src="https://github.com/user-attachments/assets/0ee2c01d-3457-40d4-9541-3b4b4fac704a" />

<img width="647" height="412" alt="Image" src="https://github.com/user-attachments/assets/12af5b2f-6341-44cd-995b-b8f815da61ee" />

I tested a fix which redirects to `jp-lazy-guide/index.md ` if you go to the main URL without any specific path and added a `requirements.txt` file to install the needed dependencies for mkdocs. The `mkdocs-git-revision-date-localized-plugin` dependency was also needed in order to build the site locally.

Changes:

- Navigating to https://lazyguidejp.github.io should take you to jp-lazy-guide/index.md
- Add mkdocs-redirects plugin
- Add requirements.txt for installing via pip


https://github.com/user-attachments/assets/5b6a2e31-f33f-49d5-8237-70964028fc69

